### PR TITLE
feat(cd): automatic deploy patch version to integration + automatic gh release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "v*.*.*-*"
 
 env:
   GITHUB_TOKEN: ${{ secrets.WRITE_PACKAGES }}
@@ -22,6 +23,8 @@ jobs:
       run: sbt clean publish
   publish-docker-image:
     runs-on: self-hosted
+    outputs:
+      should_trigger_deploy: ${{ steps.should_trigger_deploy.outputs.should_trigger_deploy }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -34,3 +37,42 @@ jobs:
         logout: false
     - name: publish docker images
       run: .github/scripts/dnd-sbt docker/Docker/publish
+    - name: set should_trigger_deploy
+      id: should_trigger_deploy
+      shell: bash
+      run: |
+        pattern='^refs/tags/v[0-9]+\.[0-9]+\.([1-9][0-9]*$|[0-9]+-.*$)'
+        echo "should_trigger_deploy=$([[ "$GITHUB_REF" =~ $pattern ]] && echo true || echo false)" >> $GITHUB_OUTPUT
+  gh-release:
+    needs: [publish-jars, publish-docker-image]
+    runs-on: self-hosted
+    steps:
+    - uses: softprops/action-gh-release@v2
+      with:
+        token: ${{ secrets.RAW_CI_PAT }}
+        generate_release_notes: true
+        draft: false
+        prerelease: ${{ contains(github.ref_name, '-') }}
+        tag_name: ${{ github.ref_name }}
+  trigger-deploy:
+      needs: publish-docker-image
+      if: needs.publish-docker-image.outputs.should_trigger_deploy == 'true'
+      runs-on: ubuntu-latest
+      steps:
+        - name: tag without 'v' prefix
+          id: extract_tag
+          run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        - name: trigger mvp-deployer workflow
+          uses: peter-evans/repository-dispatch@v3
+          with:
+            token: ${{ secrets.RAW_CI_PAT }}
+            repository: raw-labs/mvp-deployer
+            event-type: deploy-patch-das-salesforce
+            client-payload: |-
+              {
+                "aws_region": "eu-west-1",
+                "raw_version": "${{ steps.extract_tag.outputs.version }}",
+                "target_env": "integration",
+                "loaded_vars": "integration",
+                "deployer_version": "latest"
+              }


### PR DESCRIPTION
Automatically deploying fix/patch version

The logic is pretty basic since we follow semver. If the last part of the version is not ending with 0 then the update is a patch update
We add the possibility of having release candidates.
`-rc` or `-something` will also be automatically deployed to integration,

We take advantage of this pull request to enable automatic github release creation