### PR TITLE
RD-15090: Process dates, timestamps, numbers in the DAS

### DIFF
--- a/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceDatedConversionRateTable.scala
+++ b/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceDatedConversionRateTable.scala
@@ -34,25 +34,27 @@ class DASSalesforceDatedConversionRateTable(connector: DASSalesforceConnector)
       ColumnDefinition
         .newBuilder()
         .setName("iso_code")
-        .setDescription("Currency Code.")
+        .setDescription("ISO code of the currency (ISO 4217 standard).")
         .setType(Type.newBuilder().setString(StringType.newBuilder().setTriable(false).setNullable(false)).build())
         .build(),
       ColumnDefinition
         .newBuilder()
         .setName("start_date")
-        .setDescription("Date.")
-        .setType(Type.newBuilder().setDate(DateType.newBuilder().setTriable(false).setNullable(false)).build())
+        .setDescription("The date on which the effective dated exchange rate starts.")
+        .setType(Type.newBuilder().setDate(DateType.newBuilder().setTriable(false).setNullable(true)).build())
         .build(),
       ColumnDefinition
         .newBuilder()
         .setName("next_start_date")
-        .setDescription("Next Start Date.")
-        .setType(Type.newBuilder().setDate(DateType.newBuilder().setTriable(false).setNullable(false)).build())
+        .setDescription(
+          "The date on which the next effective dated exchange rate will start. Effectively the day after the end date for this exchange rate."
+        )
+        .setType(Type.newBuilder().setDate(DateType.newBuilder().setTriable(false).setNullable(true)).build())
         .build(),
       ColumnDefinition
         .newBuilder()
         .setName("conversion_rate")
-        .setDescription("Exchange Rate.")
+        .setDescription("Conversion rate of this currency type against the corporate currency.")
         .setType(Type.newBuilder().setDouble(DoubleType.newBuilder().setTriable(false).setNullable(false)).build())
         .build(),
       ColumnDefinition
@@ -60,7 +62,7 @@ class DASSalesforceDatedConversionRateTable(connector: DASSalesforceConnector)
         .setName("created_date")
         .setDescription("Created Date.")
         .setType(
-          Type.newBuilder().setTimestamp(TimestampType.newBuilder().setTriable(false).setNullable(false)).build()
+          Type.newBuilder().setTimestamp(TimestampType.newBuilder().setTriable(false).setNullable(true)).build()
         )
         .build(),
       ColumnDefinition
@@ -74,7 +76,7 @@ class DASSalesforceDatedConversionRateTable(connector: DASSalesforceConnector)
         .setName("last_modified_date")
         .setDescription("Last Modified Date.")
         .setType(
-          Type.newBuilder().setTimestamp(TimestampType.newBuilder().setTriable(false).setNullable(false)).build()
+          Type.newBuilder().setTimestamp(TimestampType.newBuilder().setTriable(false).setNullable(true)).build()
         )
         .build(),
       ColumnDefinition
@@ -88,7 +90,7 @@ class DASSalesforceDatedConversionRateTable(connector: DASSalesforceConnector)
         .setName("system_modstamp")
         .setDescription("System Modstamp.")
         .setType(
-          Type.newBuilder().setTimestamp(TimestampType.newBuilder().setTriable(false).setNullable(false)).build()
+          Type.newBuilder().setTimestamp(TimestampType.newBuilder().setTriable(false).setNullable(true)).build()
         )
         .build()
     )

--- a/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceTable.scala
+++ b/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceTable.scala
@@ -16,7 +16,6 @@ import com.rawlabs.das.sdk.{DASExecuteResult, DASSdkException, DASTable}
 import com.rawlabs.protocol.das.{ColumnDefinition, Qual, Row, SortKey, TableDefinition}
 import com.rawlabs.protocol.raw.{
   AttrType,
-  BinaryType,
   BoolType,
   DateType,
   DecimalType,
@@ -131,7 +130,9 @@ abstract class DASSalesforceTable(
         case "long" => Type.newBuilder().setLong(LongType.newBuilder().setTriable(false).setNullable(true)).build()
         case "address" => Type.newBuilder().setRecord(RecordType.newBuilder()).build()
         case "base64" =>
-          Type.newBuilder().setBinary(BinaryType.newBuilder().setTriable(false).setNullable(true)).build()
+          // Salesforce doesn't support base64 fields in SOQL queries. They are strings, not "binary data".
+          // Also the ContentVersion column version_data (base64) is advertised as string.
+          Type.newBuilder().setString(StringType.newBuilder().setTriable(false).setNullable(true)).build()
         case "time" =>
           Type.newBuilder().setTimestamp(TimestampType.newBuilder().setTriable(false).setNullable(true)).build()
         case "phone" => Type.newBuilder().setString(StringType.newBuilder().setTriable(false).setNullable(true)).build()


### PR DESCRIPTION
This is part of RD-15090 where we hit a bug when Salesforce gives us dates with year 0000.

That patch ensures that dates, timestamps, numbers, etc., are sent as advertised (following the DAS column type).

* I stumbled on cases where the Salesforce data is an `int`, but we advertise is as `double`. Hence the specific handling.
* Also it happens we advertise a column as a `timestamp` when it's received as a `date`. Hence the timestamp parsing supporting dates.
* Salesforce documents formats that can be expected for dates and timestamps (https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_valid_date_formats.htm) but this doesn't match what we get from the API (e.g. to time offsets documented as "+00:00" which we get as "+0000".), so I only prepared for what I saw we'd get.
* The `base64` column in table `content_version` is advertised by the DAS as `string`. When investigating the content of the received object, it wasn't a base64 string, it was a readable string. So I change `base64` to be `string` and I suppose from time to time it will be base64.
* Since we have a convention of reporting records with unknown fields, I left the older logic that was determining types from values (in which case dates and timestamps are going to be sent as strings).