### PR TITLE
RD-15710: Store the table definitions so that they are reused when tableDefinitions is called again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -213,5 +213,5 @@ lazy val docker = (project in file("docker"))
   .settings(
     strictBuildSettings,
     dockerSettings,
-    libraryDependencies += "com.raw-labs" %% "das-server-scala" % "0.1.5" % "compile->compile;test->test"
+    libraryDependencies += "com.raw-labs" %% "das-server-scala" % "0.1.7" % "compile->compile;test->test"
   )

--- a/src/main/scala/com/rawlabs/das/salesforce/DASSalesforce.scala
+++ b/src/main/scala/com/rawlabs/das/salesforce/DASSalesforce.scala
@@ -100,6 +100,10 @@ class DASSalesforce(options: Map[String, String]) extends DASSdk with StrictLogg
   private val dynamicTables = dynamicTableNames.map(name => new DASSalesforceDynamicTable(connector, name))
 
   private val allTables = staticTables ++ dynamicTables ++ maybeDatedConversionRateTable
+
+  // These are the table definitions that will be returned to the client. It's stored
+  // in a val to avoid recalculating it every time it's accessed. We do that because we
+  // don't expect the tables to change during the lifetime of the DAS instance.
   private val definitions = allTables.map(_.tableDefinition)
 
   override def tableDefinitions: Seq[TableDefinition] = definitions

--- a/src/main/scala/com/rawlabs/das/salesforce/DASSalesforce.scala
+++ b/src/main/scala/com/rawlabs/das/salesforce/DASSalesforce.scala
@@ -100,8 +100,9 @@ class DASSalesforce(options: Map[String, String]) extends DASSdk with StrictLogg
   private val dynamicTables = dynamicTableNames.map(name => new DASSalesforceDynamicTable(connector, name))
 
   private val allTables = staticTables ++ dynamicTables ++ maybeDatedConversionRateTable
+  private val definitions = allTables.map(_.tableDefinition)
 
-  override def tableDefinitions: Seq[TableDefinition] = allTables.map(_.tableDefinition)
+  override def tableDefinitions: Seq[TableDefinition] = definitions
 
   override def functionDefinitions: Seq[FunctionDefinition] = Seq.empty
 


### PR DESCRIPTION
This upgrade of das-server permit to cache a DAS instance and reuse it when recreating the same DAS. The code change is to store table definitions once for all in a variable, so that if the same instance is reused, it can immediately return its table definitions.

I tested the change by requesting the same DAS config in a loop and using the schema from Postgres.