### PR TITLE
RD-15138: Expose table PicklistValueInfo

### DIFF
--- a/src/main/scala/com/rawlabs/das/salesforce/DASSalesforce.scala
+++ b/src/main/scala/com/rawlabs/das/salesforce/DASSalesforce.scala
@@ -97,9 +97,22 @@ class DASSalesforce(options: Map[String, String]) extends DASSdk with StrictLogg
     }
   }
 
+  // PicklistValueInfo might be absent depending on the Salesforce API version.
+  private val maybePickListValueInfoTable: Option[DASSalesforceDynamicTable] = {
+    try {
+      val description = connector.forceApi.describeSObject("PicklistValueInfo")
+      logger.info(s"Found PicklistValueInfo (${description.getName})")
+      Some(new DASSalesforceDynamicTable(connector, "PicklistValueInfo"))
+    } catch {
+      case e: ApiException =>
+        logger.warn("PicklistValueInfo not found", e)
+        None
+    }
+  }
+
   private val dynamicTables = dynamicTableNames.map(name => new DASSalesforceDynamicTable(connector, name))
 
-  private val allTables = staticTables ++ dynamicTables ++ maybeDatedConversionRateTable
+  private val allTables = staticTables ++ dynamicTables ++ maybeDatedConversionRateTable ++ maybePickListValueInfoTable
 
   override def tableDefinitions: Seq[TableDefinition] = allTables.map(_.tableDefinition)
 

--- a/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceTable.scala
+++ b/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceTable.scala
@@ -76,6 +76,7 @@ abstract class DASSalesforceTable(
   // The staticColumns list is coming from the table definition, where it's hardcoded with good documentation.
   // The schema returned by Salesforce permits us to discard hidden ones and add dynamic ones.
   def fixHiddenAndDynamicColumns(staticColumns: Seq[ColumnDefinition]): Seq[ColumnDefinition] = {
+    logger.info(s"Fixing hidden and dynamic columns for table $tableName")
     val finalColumns = mutable.ArrayBuffer.empty[ColumnDefinition]
     // First filter the provided static columns to keep those _that are in the table schema returned by Salesforce_.
     val columns = readColumnsFromTable()
@@ -87,7 +88,10 @@ abstract class DASSalesforceTable(
       val knownColumns = staticColumns.map(_.getName).toSet
       // Second, if configured so, add the dynamic columns: columns that were returned in the Salesforce schema
       // but we haven't picked from the static columns list.
-      columns.map(_.columnDefinition).filterNot(c => knownColumns.contains(c.getName)).foreach(finalColumns += _)
+      columns.map(_.columnDefinition).filterNot(c => knownColumns.contains(c.getName)).foreach { c =>
+        logger.debug(s"Adding dynamic column ${c.getName} to table $tableName")
+        finalColumns += c
+      }
     }
     columns.foreach { c =>
       if (c.updatable) markUpdatable(c.columnDefinition.getName)


### PR DESCRIPTION
* Added `PickListValueInfo` to the tables (if present).
* Also added a couple of debug logs to monitor the progress of the import of the whole set of tables.

The table is one of those that requires a filter to be read.

```sql
# SELECT * FROM salesforce.salesforce_picklist_value_info ;
ERROR:  Error in python: _MultiThreadedRendezvous
DETAIL:  <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.INTERNAL
	details = "[{"message":"PicklistValueInfo: a filter on a reified column is required [EntityParticleId,DurableId]","errorCode":"MALFORMED_QUERY"}]"
	debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"[{\"message\":\"PicklistValueInfo: a filter on a reified column is required [EntityParticleId,DurableId]\",\"errorCode\":\"MALFORMED_QUERY\"}]", grpc_status:13, created_time:"2024-11-27T08:44:05.506791+01:00"}"
# SELECT * FROM salesforce.salesforce_picklist_value_info WHERE entity_particle_id = 'Lead.Rating';
INFO:  Setting HSTORE array OID to 175993
         id         |    durable_id    | value | label | is_default_value | is_active | valid_for | entity_particle_id 
--------------------+------------------+-------+-------+------------------+-----------+-----------+--------------------
 000000000000000AAA | Lead.Rating.Warm | Warm  | Warm  | f                | t         |           | Lead.Rating
 000000000000000AAA | Lead.Rating.Cold | Cold  | Cold  | f                | t         |           | Lead.Rating
 000000000000000AAA | Lead.Rating.Hot  | Hot   | Hot   | f                | t         |           | Lead.Rating
(3 rows)
```