### PR TITLE
Fixed RD-15259: Ignore redundant user provided custom objects

### DIFF
--- a/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceTable.scala
+++ b/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceTable.scala
@@ -29,7 +29,7 @@ import com.typesafe.scalalogging.StrictLogging
 abstract class DASSalesforceTable(
     connector: DASSalesforceConnector,
     val tableName: String,
-    salesforceObjectName: String)
+    val salesforceObjectName: String)
     extends DASTable
     with StrictLogging {
 


### PR DESCRIPTION
Tested with this below. Only one instance of each table is eventually loaded. `Lead` and `DatedConversionRate` are standard tables, and are therefore ignored as part of dynamic objects.
* `dynamic_objects 'BusinessCase__c,BusinessCase__c'`
* `dynamic_objects 'BusinessCase__c,DatedConversionRate'`
* `dynamic_objects 'BusinessCase__c,Lead'`