### PR TITLE
Fixed RD-15281: Column close_date wrongly advertised as timestamp

### DIFF
--- a/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceOpportunityTable.scala
+++ b/src/main/scala/com/rawlabs/das/salesforce/DASSalesforceOpportunityTable.scala
@@ -13,7 +13,7 @@
 package com.rawlabs.das.salesforce
 
 import com.rawlabs.protocol.das.{ColumnDefinition, TableDefinition, TableId}
-import com.rawlabs.protocol.raw.{BoolType, DoubleType, IntType, StringType, TimestampType, Type}
+import com.rawlabs.protocol.raw.{BoolType, DateType, DoubleType, IntType, StringType, TimestampType, Type}
 
 class DASSalesforceOpportunityTable(connector: DASSalesforceConnector)
     extends DASSalesforceTable(connector, "salesforce_opportunity", "Opportunity") {
@@ -71,7 +71,7 @@ class DASSalesforceOpportunityTable(connector: DASSalesforceConnector)
         .setName("close_date")
         .setDescription("Date when the opportunity is expected to close.")
         .setType(
-          Type.newBuilder().setTimestamp(TimestampType.newBuilder().setTriable(false).setNullable(true)).build()
+          Type.newBuilder().setDate(DateType.newBuilder().setTriable(false).setNullable(true)).build()
         )
         .build(),
       ColumnDefinition


### PR DESCRIPTION
```sql
SELECT *
FROM salesforce.salesforce_opportunity
WHERE close_date > CAST(NOW() AS DATE);
```
fails because we send the SOQL predicate `CloseDate > 2025-01-21T00:00:00.000000000Z` after casting the value to a timestamp (since we believe the column is a timestamp), which implies a comparison between a date and a timestamp (not supported in SOQL). With the changeset, the predicate is `CloseDate > 2025-01-21`.

```sql
SELECT *
FROM salesforce.salesforce_opportunity
WHERE close_date > CAST(NOW() AS TIMESTAMP);
```
fails because we send the SOQL predicate `CloseDate > 2025-01-21T13:43:16.000000000Z` which implies a comparison between a date and a timestamp (not supported in SOQL). With the changeset, the predicate is ignored.